### PR TITLE
Add classnames of exceptions

### DIFF
--- a/src/clj_stacktrace/repl.clj
+++ b/src/clj_stacktrace/repl.clj
@@ -52,6 +52,10 @@
 (defn method-str [parsed]
   (if (:java parsed) (java-method-str parsed) (clojure-method-str parsed)))
 
+(defn pst-class-on [on color? class]
+  (.append on (colored color? :red (str (.getName class) ": ")))
+  (.flush on))
+
 (defn pst-message-on [on color? message]
   (.append on (colored color? :red message))
   (.append on "\n")
@@ -72,9 +76,16 @@
       (.append on "\n")
       (.flush on))))
 
+(defn pst-caused-by-on
+  [on color?]
+  (.append on (colored color? :red "Caused by: "))
+  (.flush on))
+
 (defn- pst-cause-on
   [on color? exec source-width]
-  (pst-message-on on color? (str "Caused by: " (:message exec)))
+  (pst-caused-by-on on color?)
+  (pst-class-on on color? (:class exec))
+  (pst-message-on on color? (:message exec))
   (pst-elems-on on color? (:trimmed-elems exec) source-width)
   (if-let [cause (:cause exec)]
     (pst-cause-on on color? cause source-width)))
@@ -96,6 +107,7 @@
   ANSI colored if color? is true."
   (let [exec         (parse-exception e)
         source-width (find-source-width exec)]
+    (pst-class-on on color? (:class exec))
     (pst-message-on on color? (:message exec))
     (pst-elems-on on color? (:trace-elems exec) source-width)
     (if-let [cause (:cause exec)]


### PR DESCRIPTION
I'm not sure if this is desirable, but I've been having trouble with the exceptions I've been getting from lein-difftest, and I think I tracked it back to clj-stacktrace.

Without my changes, the behavior looks like this:
    user=> (use 'clj-stacktrace.repl)
    nil
    user=> (pst (RuntimeException. "foo" (RuntimeException. "bar")))
    foo
            NO_SOURCE_FILE:4 user/eval134
          Compiler.java:5424 clojure.lang.Compiler.eval
          Compiler.java:5391 clojure.lang.Compiler.eval
               core.clj:2382 clojure.core/eval
                main.clj:183 clojure.main/repl[fn]
                main.clj:204 clojure.main/repl[fn]
                main.clj:204 clojure.main/repl
             RestFn.java:422 clojure.lang.RestFn.invoke
            NO_SOURCE_FILE:1 user/eval13[fn]
                 AFn.java:24 clojure.lang.AFn.run
             Thread.java:662 java.lang.Thread.run
    Caused by: bar
    nil

With my changes, the behavior looks like this:
    user=> (use 'clj-stacktrace.repl)
    nil
    user=> (pst (RuntimeException. "foo" (RuntimeException. "bar")))
    java.lang.RuntimeException: foo
            NO_SOURCE_FILE:4 user/eval136
          Compiler.java:5424 clojure.lang.Compiler.eval
          Compiler.java:5391 clojure.lang.Compiler.eval
               core.clj:2382 clojure.core/eval
                main.clj:183 clojure.main/repl[fn]
                main.clj:204 clojure.main/repl[fn]
                main.clj:204 clojure.main/repl
             RestFn.java:422 clojure.lang.RestFn.invoke
            NO_SOURCE_FILE:1 user/eval13[fn]
                 AFn.java:24 clojure.lang.AFn.run
             Thread.java:662 java.lang.Thread.run
    Caused by: java.lang.RuntimeException: bar
    nil
    user=> 

I'm not entirely sure I understand where things went wrong, as it looks in the README like the classnames are supposed to be there to begin with, but I haven't been able to get clj-stacktrace to give me them.

Feel free to point out if I've misunderstood something, or if you have any criticism.  

Side note to Mark:  I met you briefly at the conj, and enjoyed your talk.
