### PR TITLE
Fix clojure dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject clj-stacktrace "0.2.1-SNAPSHOT"
   :description "More readable stacktraces in Clojure programs."
   :url "http://github.com/mmcgrana/clj-stacktrace"
-  :dependencies [[org.clojure/clojure "1.2.0"]]
-  :dev-dependencies [[lein-clojars "0.6.0"]])
+  :dev-dependencies [[org.clojure/clojure "1.2.1"]
+                     [lein-clojars "0.6.0"]])


### PR DESCRIPTION
That way other projects don't have end up pulling in clj-stacktrace's
preferred clojure version, and can use whatever they please.
