### PR TITLE
have clojure-ns accept class names without $ (issue #4)

### DIFF
--- a/src/clj_stacktrace/core.clj
+++ b/src/clj_stacktrace/core.clj
@@ -10,7 +10,8 @@
 (defn- clojure-ns
   "Returns the clojure namespace name implied by the bytecode class name."
   [class-name]
-  (utils/re-gsub #"_" "-" (utils/re-get #"([^$]+)\$" class-name 1)))
+  (utils/re-gsub #"_" "-" (or (utils/re-get #"([^$]+)\$" class-name 1)
+                              (utils/re-get #"(.+)\.[^.]+$" class-name 1))))
 
 ; drop everything before and including the first $
 ; drop everything after and including and the second $

--- a/test/clj_stacktrace/core_test.clj
+++ b/test/clj_stacktrace/core_test.clj
@@ -31,6 +31,9 @@
    ["user$eval__345" "invoke" nil -1
     {:clojure true :ns "user" :fn "eval" :file nil :line nil :annon-fn false}]
 
+   ["lamina.core.observable.ConstantObservable" "message" "observable.clj" 198
+    {:clojure true :ns "lamina.core.observable" :fn "lamina.core.observable.ConstantObservable" :file "observable.clj" :line 198 :annon-fn false}]
+   
    ["clojure.lang.Var" "invoke" "Var.java" 123
     {:java true :class "clojure.lang.Var" :method "invoke" :file "Var.java" :line 123}]
 


### PR DESCRIPTION
When using aleph in combination with ring's wrap-stacktrace, certain
exceptions are silently swallowed by the server.  I traced this down
to clojure-ns raising a null pointer exception for the class-name
"lamina.core.observable.ConstantObservable", which is a defrecord.

This changes clojure-ns to return "lamina.core.observable" as the ns.
clojure-fn is unchanged and returns the full string, which is probably
wrong.
