### PR TITLE
Omit frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ For example, to print a nice stack trace in a REPL:
     => (use 'clj-stacktrace.repl)
     => ("foo")
     java.lang.ClassCastException: java.lang.String cannot be cast to clojure.lang.IFn (NO_SOURCE_FILE:0)
+    => (pst)
+    java.lang.ClassCastException: java.lang.String cannot be cast to clojure.lang.IFn (NO_SOURCE_FILE:0)
            Compiler.java:5440 clojure.lang.Compiler.eval
            Compiler.java:5391 clojure.lang.Compiler.eval
                 core.clj:2382 clojure.core/eval
@@ -25,18 +27,24 @@ For example, to print a nice stack trace in a REPL:
              NO_SOURCE_FILE:2 user/eval100
            Compiler.java:5424 clojure.lang.Compiler.eval
 
-
 In stack traces printed by `pst`:
 
-* Java methods are described with the usual `name.space.ClassName.methodName` convention and Clojure functions with their own `name.space/function-name` convention.
-* Anonymous clojure functions are denoted by adding an `[fn]` to their enclosing, named function.
+* Java methods are described with the usual
+  `name.space.ClassName.methodName` convention and Clojure functions
+  with their own `name.space/function-name` convention.
+* Anonymous clojure functions are denoted by adding an `[fn]` to their
+  enclosing, named function.
 * "Caused by" cascades are shown as in regular java stack traces.
 * Elements are vertically aligned for better readability.
 * Printing is directed to `*out*`.
 
-If you want to direct the printing to somewhere other than `*out*`, either use `pst-on` to specify the output location or `pst-str` to capture the printing as a string.
+If you want to direct the printing to somewhere other than `*out*`,
+either use `pst-on` to specify the output location or `pst-str` to
+capture the printing as a string.
 
-The library also offers an API for programatically 'parsing' exceptions. This API is used internal for `pst` and can be used to e.g. improve development tools. Try for example:
+The library also offers an API for programatically 'parsing'
+exceptions. This API is used internal for `pst` and can be used to
+e.g. improve development tools. Try for example:
 
 ```clj
 (use 'clj-stacktrace.core)
@@ -46,7 +54,7 @@ The library also offers an API for programatically 'parsing' exceptions. This AP
     (parse-exception e)))
 ```
 
-If you use Leiningen, you can install clj-stacktrace on a per-user basis:
+If you use Leiningen, you can install clj-stacktrace on a user-level basis:
 
     $ lein plugin install clj-stacktrace 0.2.4
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ In stack traces printed by `pst`:
 * Printing is directed to `*out*`.
 
 If you want to direct the printing to somewhere other than `*out*`,
-either use `pst-on` to specify the output location or `pst-str` to
-capture the printing as a string.
+either use `pst-on` to specify the output location.
 
 The library also offers an API for programatically 'parsing'
 exceptions. This API is used internal for `pst` and can be used to

--- a/src/clj_stacktrace/core.clj
+++ b/src/clj_stacktrace/core.clj
@@ -76,7 +76,7 @@
         :method (.getMethodName elem)))))
 
 (defn parse-trace-elems
-  "Returns a seq of maps providing usefull information about the java stack
+  "Returns a seq of maps providing useful information about the java stack
   trace elements. See parse-trace-elem."
   [elems]
   (map parse-trace-elem elems))
@@ -110,7 +110,7 @@
       base)))
 
 (defn parse-exception
-  "Returns a Clojure map providing usefull informaiton about the exception.
+  "Returns a Clojure map providing useful information about the exception.
   The map has keys
   :class        Class of the exception.
   :message      Regular exception message string.

--- a/src/clj_stacktrace/utils.clj
+++ b/src/clj_stacktrace/utils.clj
@@ -37,3 +37,19 @@
         q3  (quartile3 coll)
         iqr (- q3 q1)]
     (int (+ q3 (/ (* 3 iqr) 2)))))
+
+(defn- omitter-fn [to-omit]
+  (if (instance? java.util.regex.Pattern to-omit)
+    ;; Curse you, non ifn regexes!
+    (comp (partial re-find to-omit) pr-str)
+    to-omit))
+
+(defn omit-frames
+  "Remove frames matching to-omit, which can be a function or regex."
+  [trace-elems to-omit]
+  (if-let [omit? (omitter-fn to-omit)]
+    (reduce (fn [trace-elems elem]
+              (if (omit? elem)
+                trace-elems
+               (conj trace-elems elem))) [] trace-elems)
+    trace-elems))

--- a/src/leiningen/hooks/clj_stacktrace_test.clj
+++ b/src/leiningen/hooks/clj_stacktrace_test.clj
@@ -3,12 +3,11 @@
         [robert.hooke :only [add-hook]]))
 
 (defn- hook-form [form project]
-  (let [pst (if (:test-color (:clj-stacktrace project))
-              'clj-stacktrace.repl/pst+
-              'clj-stacktrace.repl/pst)]
-    `(do (alter-var-root (resolve '~'clojure.stacktrace/print-cause-trace)
-                         (constantly @(resolve '~pst)))
-         ~form)))
+  `(do (alter-var-root (resolve '~'clojure.stacktrace/print-cause-trace)
+                       (constantly (fn [e#]
+                                     (@(resolve '~'project-pst) e#
+                                      ~(:clj-stacktrace project)))))
+       ~form))
 
 (defn- add-stacktrace-hook [eval-in-project project form & [h s init]]
   (eval-in-project project (hook-form form project)

--- a/src/leiningen/hooks/clj_stacktrace_test.clj
+++ b/src/leiningen/hooks/clj_stacktrace_test.clj
@@ -5,7 +5,7 @@
 (defn- hook-form [form project]
   `(do (alter-var-root (resolve '~'clojure.stacktrace/print-cause-trace)
                        (constantly (fn [e#]
-                                     (@(resolve '~'project-pst) e#
+                                     (@(resolve '~'pst) e#
                                       ~(:clj-stacktrace project)))))
        ~form))
 

--- a/test/clj_stacktrace/repl_test.clj
+++ b/test/clj_stacktrace/repl_test.clj
@@ -26,8 +26,8 @@
 (deftest test-omit
   (with-cascading-exception e
     (is (not (re-find #"repl-test" (with-out-str
-                                     (pst e :to-omit #"repl-test")))))
+                                     (pst e :omit #"repl-test")))))
     (is (not (re-find #"Compiler.java"
                       (with-out-str
-                        (pst e :to-omit (fn [e]
-                                          (= "Compiler.java" (:file e))))))))))
+                        (pst e :omit (fn [e]
+                                       (= "Compiler.java" (:file e))))))))))

--- a/test/clj_stacktrace/repl_test.clj
+++ b/test/clj_stacktrace/repl_test.clj
@@ -1,7 +1,6 @@
 (ns clj-stacktrace.repl-test
-  (:use clojure.test)
-  (:use clj-stacktrace.utils)
-  (:use clj-stacktrace.repl))
+  (:use [clojure.test]
+        [clj-stacktrace.repl]))
 
 (defmacro with-cascading-exception
   "Execute body in the context of a variable bound to an exception instance
@@ -18,14 +17,17 @@
     (binding [*e e]
       (is (with-out-str (pst))))))
 
-(deftest test-pst-str
-  (with-cascading-exception e
-    (is (pst-str e))
-    (binding [*e e]
-      (is (pst-str)))))
-
 (deftest test-pst+
   (with-cascading-exception e
     (is (with-out-str (pst+ e)))
     (binding [*e e]
       (is (with-out-str (pst+))))))
+
+(deftest test-omit
+  (with-cascading-exception e
+    (is (not (re-find #"repl-test" (with-out-str
+                                     (pst e :to-omit #"repl-test")))))
+    (is (not (re-find #"Compiler.java"
+                      (with-out-str
+                        (pst e :to-omit (fn [e]
+                                          (= "Compiler.java" (:file e))))))))))


### PR DESCRIPTION
Would like to get some discussion going on this. The meat is in the `omit-frames` function in `utils.clj`, but the notion of accepting an options map in the `pst` function is something that will probably be used more in the future; in particular @alexbaranosky wants to allow the colors to be customized.

Thoughts?
