### PR TITLE
Replace @ in README with deref

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ basis. Just add the following to `~/.lein/profiles.clj`:
                                             'print-cause-trace)
                            new (ns-resolve (doto 'clj-stacktrace.repl require)
                                            'pst)]
-                       (alter-var-root orig (constantly @new)))]}}
+                       (alter-var-root orig (constantly (deref new))))]}}
 ```
 
 The `:injections` clause replaces the built-in stack trace printing


### PR DESCRIPTION
Some lein plugins, such as [lein-ancient](https://github.com/xsc/lein-ancient), read profiles.clj as EDN. The @ reader macro is not valid EDN, so I changed the example in the README to use deref instead.

Exact usage: https://github.com/xsc/lein-ancient/blob/master/src/leiningen/ancient/utils/io.clj#L93
