### PR TITLE
Update library version in README to the latest: 0.2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you use Leiningen, you can install clj-stacktrace on a user-wide
 basis. Just add the following to `~/.lein/profiles.clj`:
 
 ```clj
-{:user {:dependencies [[clj-stacktrace "0.2.7"]]
+{:user {:dependencies [[clj-stacktrace "0.2.8"]]
         :injections [(let [orig (ns-resolve (doto 'clojure.stacktrace require)
                                             'print-cause-trace)
                            new (ns-resolve (doto 'clj-stacktrace.repl require)


### PR DESCRIPTION
This is a semi-automated pull request intended to bring README up to date and help developers to use latest version of clj-stacktrace.  

We're sorry if you already know about this issue and out-dated version in README is intended. Simply close this request in that case. 

You can also setup [Hatnik](http://hatnik.com) to generate similar pull requests in future in case you forget to update README. Please check [instructions](https://gist.github.com/nbeloglazov/2eb91a21cb3fb97a2a54). 

Hatnik Team