### PR TITLE
Update to latest name mangling map from Clojure

### DIFF
--- a/src/clj_stacktrace/core.clj
+++ b/src/clj_stacktrace/core.clj
@@ -20,18 +20,34 @@
 ;; drop any __xyz suffixes
 ;; sub _PLACEHOLDER_ for the corresponding char
 (def clojure-fn-subs
-  [[#"^[^$]*\$" ""]
-   [#"\$.*"    ""]
-   [#"__\d+.*"  ""]
-   [#"_QMARK_"  "?"]
-   [#"_BANG_"   "!"]
-   [#"_PLUS_"   "+"]
-   [#"_GT_"     ">"]
-   [#"_LT_"     "<"]
-   [#"_EQ_"     "="]
-   [#"_STAR_"   "*"]
-   [#"_SLASH_"  "/"]
-   [#"_"        "-"]])
+  [[#"^[^$]*\$"       ""]
+   [#"\$.*"           ""]
+   [#"__\d+.*"        ""]
+   [#"_AMPERSAND_"    "&"]
+   [#"_BANG_"         "!"]
+   [#"_BAR_"          "|"]
+   [#"_BSLASH_"       "\\"]
+   [#"_CARET_"        "^"]
+   [#"_CIRCA_"        "@"]
+   [#"_COLON_"        ":"]
+   [#"_DOT_"          "."]
+   [#"_DOUBLEQUOTE_"  "\""]
+   [#"_EQ_"           "="]
+   [#"_GT_"           ">"]
+   [#"_LBRACE_"       "{"]
+   [#"_LBRACK_"       "["]
+   [#"_LT_"           "<"]
+   [#"_PERCENT_"      "%"]
+   [#"_PLUS_"         "+"]
+   [#"_QMARK_"        "?"]
+   [#"_RBRACE_"       "}"]
+   [#"_RBRACK_"       "]"]
+   [#"_SHARP_"        "#"]
+   [#"_SINGLEQUOTE_"  "'"]
+   [#"_SLASH_"        "/"]
+   [#"_STAR_"         "*"]
+   [#"_TILDE_"        "~"]
+   [#"_"              "-"]])
 
 (defn- clojure-fn
   "Returns the clojure function name implied by the bytecode class name."

--- a/test/clj_stacktrace/core_test.clj
+++ b/test/clj_stacktrace/core_test.clj
@@ -20,6 +20,14 @@
     {:clojure true :ns "foo.bar" :fn "biz-bat?"
      :file "bar.clj" :line 456 :anon-fn true}]
 
+   ["foo.bar$biz_SINGLEQUOTE__bar__448" "invoke" "bar.clj" 456
+    {:clojure true :ns "foo.bar" :fn "biz'-bar"
+     :file "bar.clj" :line 456 :anon-fn false}]
+
+   ["foo.bar$biz_DOT_bat__448" "invoke" "bar.clj" 456
+    {:clojure true :ns "foo.bar" :fn "biz.bat"
+     :file "bar.clj" :line 456 :anon-fn false}]
+
    ["foo.bar$repl$fn__5629.invoke" "invoke" "bar.clj" 456
     {:clojure true :ns "foo.bar" :fn "repl"
      :file "bar.clj" :line 456 :anon-fn true}]


### PR DESCRIPTION
Hi,

I noticed that `(clj-stacktrace.repl/method-str)` was not handling `_SINGLEQUOTE_`, so I updated the name translation map to the latest one latest one I found in the [Clojure source code](https://github.com/clojure/clojure/blob/2e76c57d3b7672ce5eca096ed2059d9a1dd379d0/src/jvm/clojure/lang/Compiler.java#L2794-L2819).

I'd appreciate it if you would release this as `0.2.9`. :)
